### PR TITLE
Add quotes around true/false.

### DIFF
--- a/minecraft-server.yaml
+++ b/minecraft-server.yaml
@@ -103,31 +103,31 @@ parameters:
     label: Spawn Animals
     description: Spawn animals
     type: string
-    default: true
+    default: "true"
     constraints:
     - allowed_values:
-      - true
-      - false
+      - "true"
+      - "false"
 
   minecraft_spawn_npcs:
     label: Spawn Villagers
     description: Spawn villagers
     type: string
-    default: true
+    default: "true"
     constraints:
     - allowed_values:
-      - true
-      - false
+      - "true"
+      - "false"
 
   minecraft_spawn_monsters:
     label: Spawn Monsters
     description: Spawn monsters
     type: string
-    default: true
+    default: "true"
     constraints:
     - allowed_values:
-      - true
-      - false
+      - "true"
+      - "false"
 
   kitchen:
     description: URL for the kitchen to use


### PR DESCRIPTION
To make sure they're YAML strings.  Otherwise, the template creation
will fail with:

heat stack-create -f https://raw.githubusercontent.com/rackspace-orchestration-templates/minecraft/master/minecraft-server.yaml -P ssh_keypair_name=jasond1 -P minecraft_spawn_animals=true m1
ERROR: "true" is not an allowed value [True, False]
